### PR TITLE
Option to filter guests by type

### DIFF
--- a/vdiclient.ini.example
+++ b/vdiclient.ini.example
@@ -13,7 +13,8 @@ kiosk = False
 fullscreen = True
 # Enable displaying SPICE ini file before opening virt-viewer
 inidebug = False
-
+# Select which guest types to display. Acceptable values: both, lxc, qemu
+guest_type = both
 
 [Authentication]
 # This is the authentication backend that will be used to authenticate
@@ -26,7 +27,7 @@ tls_verify = false
 #user = user
 # API Token Name
 #token_name = dvi
-#API Token Value
+# API Token Value
 #token_value = xxx-x-x-x-xxx
 
 [Hosts]

--- a/vdiclient.py
+++ b/vdiclient.py
@@ -38,6 +38,7 @@ class G:
 	inidebug = False
 	addl_params = None
 	theme = 'LightBlue'
+	guest_type = 'both'
 
 def get_dpi():
 	import ctypes
@@ -113,6 +114,8 @@ def loadconfig(config_location = None):
 			G.fullscreen = config['General'].getboolean('fullscreen')
 		if 'inidebug' in config['General']:
 			G.inidebug = config['General'].getboolean('inidebug')
+		if 'guest_type' in config['General']:
+			G.guest_type = config['General']['guest_type']
 	if not 'Authentication' in config:
 		win_popup_button(f'Unable to read supplied configuration:\nNo `Authentication` section defined!', 'OK')
 		return False
@@ -189,7 +192,10 @@ def getvms():
 		for vm in G.proxmox.cluster.resources.get(type='vm'):
 			if vm['template']:
 				continue
-			vms.append(vm)
+			if G.guest_type == 'both':
+				vms.append(vm)
+			elif G.guest_type == vm['type']:
+				vms.append(vm)
 		return vms
 	except proxmoxer.core.ResourceException as e:
 		win_popup_button(f"Unable to display list of VMs:\n {e!r}", 'OK')

--- a/vdiclient.py
+++ b/vdiclient.py
@@ -187,6 +187,8 @@ def getvms():
 	vms = []
 	try:
 		for vm in G.proxmox.cluster.resources.get(type='vm'):
+			if vm['template']:
+				continue
 			vms.append(vm)
 		return vms
 	except proxmoxer.core.ResourceException as e:


### PR DESCRIPTION
I added an option to allow selecting between displaying only LXCs or only QEMUs or both types.
I also excluded templates because you can't start them anyways.

To further enhance this feature, someone could add an option to the UI to select between the types. But that is beyond me.