### PR TITLE
check if template key exists

### DIFF
--- a/vdiclient.py
+++ b/vdiclient.py
@@ -190,7 +190,7 @@ def getvms():
 	vms = []
 	try:
 		for vm in G.proxmox.cluster.resources.get(type='vm'):
-			if vm['template']:
+			if 'template' in vm and vm['template']:
 				continue
 			if G.guest_type == 'both':
 				vms.append(vm)


### PR DESCRIPTION
Fixes crash when trying to access `template` key when it does not exist. LXCs are not able to be templates so the key is not used in that case.
