### PR TITLE
Prevent exceptions when a node is offline

### DIFF
--- a/vdiclient.py
+++ b/vdiclient.py
@@ -164,9 +164,9 @@ def setmainlayout():
 	if G.totp:
 		layout.append([sg.Text("OTP Key", size =(12*G.scaling, 1), font=["Helvetica", 12]), sg.InputText(key='-totp-', font=["Helvetica", 12])])
 	if G.kiosk:
-		layout.append([sg.Button("Log In", font=["Helvetica", 14])])
+		layout.append([sg.Button("Log In", font=["Helvetica", 14], bind_return_key=True)])
 	else:
-		layout.append([sg.Button("Log In", font=["Helvetica", 14]), sg.Button("Cancel", font=["Helvetica", 14])])
+		layout.append([sg.Button("Log In", font=["Helvetica", 14], bind_return_key=True), sg.Button("Cancel", font=["Helvetica", 14])])
 	return layout
 
 def getvms(listonly = False):

--- a/vdiclient.py
+++ b/vdiclient.py
@@ -172,7 +172,14 @@ def setmainlayout():
 def getvms(listonly = False):
 	vms = []
 	try:
+		nodes = []
+		for node in G.proxmox.cluster.resources.get(type='node'):
+			if node['status'] == 'online':
+				nodes.append(node['node'])
+
 		for vm in G.proxmox.cluster.resources.get(type='vm'):
+			if vm['node'] not in nodes:
+				continue
 			if 'template' in vm and vm['template']:
 				continue
 			if G.guest_type == 'both' or G.guest_type == vm['type']:


### PR DESCRIPTION
I recently discovered this tool and i quite like it, however I've encountered a bit of an issue. When I have a node offline it crashes with a `KeyError` exception. I'm not a python coder but i figured I'd have a punt at fixing instead of just complaining.

I've added a little filter to only show VMs for nodes that are online. I'm not sure if
this approach is suitable for all use cases but as mine is a homelab where I want my nodes off when i'm not using them it makes sense for me.

As a little freebie I set the enter key to submit the log in form. Its just instinctive behaviour and i made that mistake repeatedly while testing this change.

```
 ./vdiclient.py         
Traceback (most recent call last):
  File "<path>/PVE-VDIClient/./vdiclient.py", line 489, in <module>
    sys.exit(main())
  File "<path>/PVE-VDIClient/./vdiclient.py", line 479, in main
    vmstat = showvms()
  File "<path>/PVE-VDIClient/./vdiclient.py", line 410, in showvms
    vmlist = getvms(listonly=True)
  File "<path>/PVE-VDIClient/./vdiclient.py", line 183, in getvms
    'name': vm['name'],
KeyError: 'name'
```