### PR TITLE
adding timeout to authentication section

### DIFF
--- a/vdiclient.ini.example
+++ b/vdiclient.ini.example
@@ -38,6 +38,8 @@ hostpool = {
 auth_backend = pve
 # If enabled, 2FA TOTP entry dialog will show
 auth_totp = false
+# Set timeout in seconds for login. Defaults to 5
+# auth_timeout = 15 
 # If disabled, TLS certificate will not be checked
 tls_verify = false
 # User name (if using token)

--- a/vdiclient.py
+++ b/vdiclient.py
@@ -176,6 +176,7 @@ def loadconfig(config_location = None, config_type='file', config_username = Non
 					'verify_ssl' : True,
 					'pwresetcmd' : None,
 					'auto_vmid' : None,
+					'timeout' : 5,
 					'knock_seq': []
 				}
 				try:
@@ -198,6 +199,8 @@ def loadconfig(config_location = None, config_type='file', config_username = Non
 					G.hosts[group]['token_value'] = config[section]['token_value']
 				if 'auth_totp' in config[section]:
 					G.hosts[group]['totp'] = config[section].getboolean('auth_totp')
+				if 'auth_timeout' in config[section]:
+					G.hosts[group]['timeout'] = config[section].getint('auth_timeout')
 				if 'tls_verify' in config[section]:
 					G.hosts[group]['verify_ssl'] = config[section].getboolean('tls_verify')
 				if 'pwresetcmd' in config[section]:
@@ -698,7 +701,8 @@ def pveauth(username, passwd=None, totp=None):
 						user=f"{username}@{G.hosts[G.current_hostset]['backend']}",
 						token_name=G.hosts[G.current_hostset]['token_name'],
 						token_value=G.hosts[G.current_hostset]['token_value'],
-						verify_ssl=G.hosts[G.current_hostset]['verify_ssl'], 
+						verify_ssl=G.hosts[G.current_hostset]['verify_ssl'],
+						timeout=G.hosts[G.current_hostset]['timeout'],
 						port=port
 					)
 				elif totp:
@@ -708,6 +712,7 @@ def pveauth(username, passwd=None, totp=None):
 						otp=totp,
 						password=passwd,
 						verify_ssl=G.hosts[G.current_hostset]['verify_ssl'],
+						timeout=G.hosts[G.current_hostset]['timeout'],
 						port=port
 					)
 				else:
@@ -716,6 +721,7 @@ def pveauth(username, passwd=None, totp=None):
 						user=f"{username}@{G.hosts[G.current_hostset]['backend']}",
 						password=passwd,
 						verify_ssl=G.hosts[G.current_hostset]['verify_ssl'],
+						timeout=G.hosts[G.current_hostset]['timeout'],
 						port=port
 					)
 				connected = True


### PR DESCRIPTION
I added the possibility to configure an authentication timeout, since proxmoxer supports this argument.
This applies for each config section, so for each cluster individually. Main reason is because of different setups/realms.

Default is still set to 5 seconds if variable is unset. Updated and explained also in example-config file.

I would love to get some feedback.